### PR TITLE
 Add GeoServer workspace and datastore management UI

### DIFF
--- a/geoserver_manager/__about__.py
+++ b/geoserver_manager/__about__.py
@@ -61,15 +61,15 @@ def plugin_metadata_as_dict() -> dict:
 __plugin_md__: dict = plugin_metadata_as_dict()
 
 __author__: str = __plugin_md__.get("general").get("author")
-__copyright__: str = "2026 - {0}, {1}".format(
-    date.today().year, __author__
-)
+__copyright__: str = "2026 - {0}, {1}".format(date.today().year, __author__)
 __email__: str = __plugin_md__.get("general").get("email")
 __icon_path__: Path = DIR_PLUGIN_ROOT.resolve() / __plugin_md__.get("general").get(
     "icon"
 )
 __keywords__: list = [
-    t.strip() for t in __plugin_md__.get("general").get("repository").split("tags")
+    t.strip()
+    for t in __plugin_md__.get("general").get("tags", "").split(",")
+    if t.strip()
 ]
 __license__: str = "GPLv2+"
 __plugin_dependencies__ = [

--- a/geoserver_manager/__init__.py
+++ b/geoserver_manager/__init__.py
@@ -13,38 +13,6 @@ def classFactory(iface):
     :param iface: A QGIS interface instance.
     :type iface: QgsInterface
     """
-    import os
-    import sys
-
-    this_dir = os.path.dirname(__file__)
-
-    # Order matters: load transitive deps first, then geoservercloud
-    whls = [
-        os.path.join(this_dir, "extras", "xmltodict-1.0.4-py3-none-any.whl"),
-        os.path.join(this_dir, "extras", "geoservercloud-0.8.5-py3-none-any.whl"),
-    ]
-
-    for whl_path in whls:
-        if os.path.exists(whl_path) and whl_path not in sys.path:
-            sys.path.insert(0, whl_path)
-
-    # Register with pkg_resources if available
-    try:
-        import geoservercloud  # noqa: F401
-    except ImportError:
-        try:
-            import pkg_resources
-
-            for whl_path in whls:
-                if os.path.exists(whl_path):
-                    whl_name = os.path.basename(whl_path)
-                    dist = pkg_resources.Distribution.from_location(
-                        whl_path, whl_name
-                    )
-                    pkg_resources.working_set.add(dist)
-        except Exception:
-            pass
-
     from .plugin_main import GeoServerManagerPlugin
 
     return GeoServerManagerPlugin(iface)

--- a/geoserver_manager/gui/dlg_main.py
+++ b/geoserver_manager/gui/dlg_main.py
@@ -48,7 +48,9 @@ class GeoServerMainDialog(QDialog, WorkspaceTabMixin, DatastoreTabMixin):
 
         # Inline message bar (sits above the splitter)
         self.message_bar = QgsMessageBar(self)
-        self.message_bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.message_bar.setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+        )
         self.message_bar_layout.insertWidget(0, self.message_bar)
 
         self.splitter.setSizes([160, 740])
@@ -280,9 +282,9 @@ class GeoServerMainDialog(QDialog, WorkspaceTabMixin, DatastoreTabMixin):
         header = self.resultsTable.horizontalHeader()
         for i in range(len(columns)):
             if columns[i] == self.tr("Actions"):
-                header.setSectionResizeMode(i, QHeaderView.ResizeToContents)
+                header.setSectionResizeMode(i, QHeaderView.ResizeMode.ResizeToContents)
             else:
-                header.setSectionResizeMode(i, QHeaderView.Stretch)
+                header.setSectionResizeMode(i, QHeaderView.ResizeMode.Stretch)
 
     def _on_selection_changed(self):
         """Enable or disable the Delete Selected button based on selection."""
@@ -351,7 +353,7 @@ class GeoServerMainDialog(QDialog, WorkspaceTabMixin, DatastoreTabMixin):
                     # Clickable cell
                     link = QPushButton(str(val))
                     link.setFlat(True)
-                    link.setCursor(Qt.PointingHandCursor)
+                    link.setCursor(Qt.CursorShape.PointingHandCursor)
                     link.setStyleSheet(
                         "text-align: left; color: palette(link); "
                         "text-decoration: underline; padding: 0 4px;"
@@ -452,10 +454,10 @@ class GeoServerMainDialog(QDialog, WorkspaceTabMixin, DatastoreTabMixin):
                 "Are you sure you want to delete {type} '{name}'?\n\n"
                 "This action cannot be undone."
             ).format(type=resource_type, name=name),
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
-        return reply == QMessageBox.Yes
+        return reply == QMessageBox.StandardButton.Yes
 
     # -- Dialog actions ----------------------------------------------------
 

--- a/geoserver_manager/gui/dlg_main.py
+++ b/geoserver_manager/gui/dlg_main.py
@@ -1,134 +1,468 @@
 #! python3  # noqa: E265
 
 """
-Main plugin dialog.
+Main plugin dialog — GeoServer resource browser.
+
+Left panel: navigation tabs (Workspaces, Datastores, Layers, Styles).
+Right panel: search bar + results table for the selected tab.
 """
 
-# standard
-import sys
+from functools import partial
 from pathlib import Path
 
-# PyQGIS
+from qgis.core import Qgis, QgsApplication
+from qgis.gui import QgsMessageBar
 from qgis.PyQt import uic
-from qgis.PyQt.QtWidgets import QDialog, QMessageBox
+from qgis.PyQt.QtCore import QByteArray, Qt, QTimer
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QTableWidgetItem,
+    QWidget,
+)
 
-# project
+from geoserver_manager.__about__ import __title__
+from geoserver_manager.gui.tab_datastores import DatastoreTabMixin
+from geoserver_manager.gui.tab_workspaces import WorkspaceTabMixin
+from geoserver_manager.toolbelt.log_handler import PlgLogger
 from geoserver_manager.toolbelt.preferences import PlgOptionsManager
 
-# ############################################################################
-# ########## Classes ###############
-# ##################################
 
-class GeoServerMainDialog(QDialog):
-    """Main dialog window for the plugin."""
+class GeoServerMainDialog(QDialog, WorkspaceTabMixin, DatastoreTabMixin):
+    """Main dialog — GeoServer resource browser."""
 
-    def __init__(self, parent=None, iface=None) -> None:
-        """Constructor."""
+    def __init__(self, parent=None, iface=None):
         super().__init__(parent)
         self.iface = iface
-        
-        # Load the UI file.
+        self.log = PlgLogger().log
+        self.gs = None
+
         uic.loadUi(Path(__file__).parent / "dlg_main.ui", self)
-        
         self.plg_settings = PlgOptionsManager()
-        
-        # Wire up buttons
-        self.btn_test_connection.clicked.connect(self.test_connection)
-        self.btn_edit_credentials.clicked.connect(self.edit_credentials)
-        
-        self.refresh_ui()
 
-    def refresh_ui(self) -> None:
-        """Refresh the UI with current settings."""
-        settings = self.plg_settings.get_plg_settings()
-        
-        if settings.has_credentials():
-            self.lbl_url_value.setText(settings.geoserver_url)
-            self.lbl_status_value.setText("Ready to test")
-            self.lbl_status_value.setStyleSheet("color: black;")
-            self.btn_test_connection.setEnabled(True)
-        else:
-            self.lbl_url_value.setText("Not configured")
-            self.lbl_status_value.setText("Missing credentials")
-            self.lbl_status_value.setStyleSheet("color: red;")
-            self.btn_test_connection.setEnabled(False)
+        # Inline message bar (sits above the splitter)
+        self.message_bar = QgsMessageBar(self)
+        self.message_bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.message_bar_layout.insertWidget(0, self.message_bar)
 
-    def edit_credentials(self) -> None:
-        """Open the QGIS Options dialog to the plugin's settings tab."""
-        if self.iface:
-            # We must close this dialog first before showing settings since settings is modal
-            self.hide()
-            from geoserver_manager.__about__ import __title__
-            self.iface.showOptionsDialog(currentPage="mOptionsPage{}".format(__title__))
-            # Refresh UI after settings dialog closes, incase credentials changed.
-            self.refresh_ui()
-            self.show()
+        self.splitter.setSizes([160, 740])
 
-    def test_connection(self) -> None:
-        """Test the connection to GeoServer using geoservercloud."""
+        self._setup_nav()
+
+        # Pagination state
+        self._page_size = 20
+        self._current_page = 0
+        self._all_rows = []  # all fetched rows (list of list-of-str)
+        self._filtered_rows = []  # rows after search filter
+        self._row_actions = []  # list of (icon, tooltip, callback) for action buttons
+        self._name_click_callback = None  # callback(row_data) when name is clicked
+        self._extra_click_callbacks = {}  # extra col_index -> callback(row_data)
+        self._delete_selected_callback = (
+            None  # callback(list[row_data]) for bulk delete
+        )
+
+        # Tooltips
+        self.btn_close.setToolTip(self.tr("Close the dialog"))
+        self.btn_refresh.setToolTip(self.tr("Refresh resources from the GeoServer"))
+        self.btn_edit_credentials.setToolTip(
+            self.tr("Open settings to edit GeoServer credentials")
+        )
+        self.searchBox.setToolTip(
+            self.tr("Search resources by name or other attributes")
+        )
+        self.btn_page_first.setToolTip(self.tr("First page"))
+        self.btn_page_prev.setToolTip(self.tr("Previous page"))
+        self.btn_page_next.setToolTip(self.tr("Next page"))
+        self.btn_page_last.setToolTip(self.tr("Last page"))
+        self.btn_delete_selected.setToolTip(self.tr("Delete the selected resources"))
+
+        # Signals
+        self.btn_close.clicked.connect(self.close)
+        self.btn_refresh.clicked.connect(lambda: self.refresh_ui(show_message=True))
+        self.btn_edit_credentials.clicked.connect(self._edit_credentials)
+        self.navList.currentRowChanged.connect(self._on_nav_changed)
+        self._search_timer = QTimer(self)
+        self._search_timer.setSingleShot(True)
+        self._search_timer.setInterval(300)
+        self._search_timer.timeout.connect(self._apply_filter)
+        self.searchBox.textChanged.connect(lambda _: self._search_timer.start())
+        self.btn_page_first.clicked.connect(self._page_first)
+        self.btn_page_prev.clicked.connect(self._page_prev)
+        self.btn_page_next.clicked.connect(self._page_next)
+        self.btn_page_last.clicked.connect(self._page_last)
+        self.resultsTable.itemSelectionChanged.connect(self._on_selection_changed)
+
+        self._restore_settings()
+
+    # -- Settings persistence -----------------------------------------------
+
+    def closeEvent(self, event):
+        self._store_settings()
+        super().closeEvent(event)
+
+    def _store_settings(self):
+        """Persist dialog geometry and splitter sizes."""
+        self.plg_settings.set_value_from_key("dialog_geometry", self.saveGeometry())
+        self.plg_settings.set_value_from_key(
+            "splitter_state", self.splitter.saveState()
+        )
+
+    def _restore_settings(self):
+        """Restore dialog geometry and splitter sizes."""
+        geometry = self.plg_settings.get_value_from_key(
+            "dialog_geometry", None, QByteArray
+        )
+        if geometry is not None:
+            self.restoreGeometry(geometry)
+
+        splitter_state = self.plg_settings.get_value_from_key(
+            "splitter_state", None, QByteArray
+        )
+        if splitter_state is not None:
+            self.splitter.restoreState(splitter_state)
+
+    # -- Messages (inline banners) -----------------------------------------
+
+    def show_success_message(self, text):
+        self.message_bar.pushMessage(
+            self.tr("Success"), text, Qgis.MessageLevel.Success, 5
+        )
+
+    def show_error_message(self, text):
+        self.message_bar.pushMessage(
+            self.tr("Error"), text, Qgis.MessageLevel.Critical, 5
+        )
+
+    def show_warning_message(self, text):
+        self.message_bar.pushMessage(
+            self.tr("Warning"), text, Qgis.MessageLevel.Warning, 5
+        )
+
+    # -- Connection --------------------------------------------------------
+
+    def _connect(self):
+        """Create a GeoServerCloud client from stored credentials.
+        Returns True on success."""
         settings = self.plg_settings.get_plg_settings()
 
         if not settings.has_credentials():
-            QMessageBox.warning(
-                self,
-                "Incomplete Credentials",
-                "Please configure the GeoServer URL and authentication first.",
+            self._set_status(self.tr("Not configured"), "red")
+            self.show_warning_message(
+                self.tr("GeoServer not configured — open Settings to add credentials.")
             )
-            return
+            self.gs = None
+            return False
 
-        self.lbl_status_value.setText("Connecting...")
-        self.lbl_status_value.setStyleSheet("color: orange;")
-        self.repaint()  # Force UI update before blocking call
+        username, password = settings.get_credentials()
+        if not username or not password:
+            self._set_status(self.tr("Auth error"), "red")
+            self.show_error_message(
+                self.tr("Could not read credentials from the auth store.")
+            )
+            self.gs = None
+            return False
 
         try:
             from geoservercloud import GeoServerCloud
 
-            # Retrieve credentials from the encrypted auth store
-            username, password = settings.get_credentials()
-            if not username or not password:
-                self.lbl_status_value.setText("Auth config incomplete")
-                self.lbl_status_value.setStyleSheet("color: red;")
-                QMessageBox.warning(
-                    self,
-                    "Authentication Error",
-                    "Could not retrieve username/password from the "
-                    "selected authentication configuration.\n\n"
-                    "Please check your auth config in Settings.",
-                )
-                return
-
-            gs = GeoServerCloud(
+            self.gs = GeoServerCloud(
                 url=settings.geoserver_url,
                 user=username,
                 password=password,
             )
-
-            # get_workspaces returns (list_or_error_str, status_code)
-            result, status_code = gs.get_workspaces()
-            if isinstance(result, str):
-                # Error string returned
-                raise Exception(f"HTTP {status_code}: {result}")
-
-            num_wksp = len(result) if result else 0
-            self.lbl_status_value.setText(
-                f"Connected ({num_wksp} workspaces)"
+            self._set_status(
+                self.tr("Connected — {}").format(settings.geoserver_url), "green"
             )
-            self.lbl_status_value.setStyleSheet("color: green;")
-
-        except ImportError:
-            self.lbl_status_value.setText("Missing: geoservercloud")
-            self.lbl_status_value.setStyleSheet("color: red;")
-            QMessageBox.critical(
-                self,
-                "Error",
-                "geoservercloud library not installed. "
-                "Please check plugin logs.",
-            )
+            return True
         except Exception as e:
-            self.lbl_status_value.setText("Connection failed")
-            self.lbl_status_value.setStyleSheet("color: red;")
-            QMessageBox.warning(
-                self,
-                "Connection Failed",
-                f"Failed to connect to GeoServer:\n\n{e}",
+            self._set_status(self.tr("Connection error"), "red")
+            self.show_error_message(self.tr("Failed to connect: {}").format(e))
+            self.log(f"Connection error: {e}", log_level=Qgis.MessageLevel.Critical)
+            self.gs = None
+            return False
+
+    def _set_status(self, text, color="black"):
+        self.lbl_status.setText(text)
+        self.lbl_status.setStyleSheet(f"color: {color};")
+
+    # -- Public entry point ------------------------------------------------
+
+    def refresh_ui(self, show_message=False):
+        """Connect and reload the current tab."""
+        if self._connect():
+            self._on_nav_changed(self.navList.currentRow())
+            if show_message:
+                self.show_success_message(self.tr("Resources loaded."))
+        else:
+            self.resultsTable.setRowCount(0)
+
+    # -- Left navigation ---------------------------------------------------
+
+    def _setup_nav(self):
+        """Build the navigation tabs on the left."""
+        self.navList.clear()
+        tabs = [
+            ("Workspaces", "mIconFolder.svg"),
+            ("Datastores", "mIconDbSchema.svg"),
+            # ("Layers",     "mIconVector.svg"),
+            # ("Styles",     "mIconRendererCategory.svg"),
+        ]
+        for label, icon in tabs:
+            self.navList.addItem(
+                QListWidgetItem(QIcon(QgsApplication.iconPath(icon)), label)
             )
+        if self.navList.count():
+            self.navList.setCurrentRow(0)
+
+    def _on_nav_changed(self, index):
+        """Load data for the selected navigation tab."""
+        if not self.gs or index < 0:
+            return
+        self.searchBox.clear()
+
+        # Reset per-tab state
+        self.btn_add.setVisible(False)
+        self.btn_delete_selected.setVisible(False)
+        self._name_click_callback = None
+        self._delete_selected_callback = None
+        self._row_actions = []
+
+        label = self.navList.item(index).text()
+
+        # Route to the appropriate loader
+        if label == "Workspaces":
+            self._load_workspaces()
+        elif label == "Datastores":
+            self._load_datastores()
+        # elif label == "Layers":
+        #     self._load_layers()
+        # elif label == "Styles":
+        #     self._load_styles()
+
+    # -- Reusable table helpers --------------------------------------------
+
+    def _setup_add_button(self, text, tooltip, callback):
+        """Configure the header Add button for the current tab."""
+        self.btn_add.setText(text)
+        self.btn_add.setToolTip(tooltip)
+        self.btn_add.setVisible(True)
+        try:
+            self.btn_add.clicked.disconnect()
+        except TypeError:
+            pass
+        self.btn_add.clicked.connect(callback)
+
+    def _setup_delete_selected_button(self, callback):
+        """Configure the header Delete Selected button for the current tab."""
+        self.btn_delete_selected.setVisible(True)
+        self.btn_delete_selected.setEnabled(False)
+        self._delete_selected_callback = callback
+        try:
+            self.btn_delete_selected.clicked.disconnect()
+        except TypeError:
+            pass
+        self.btn_delete_selected.clicked.connect(
+            lambda: callback(self._get_selected_rows())
+        )
+
+    def _setup_table(self, columns):
+        """Reset the table with the given column headers."""
+        self.resultsTable.clear()
+        self.resultsTable.setColumnCount(len(columns))
+        self.resultsTable.setHorizontalHeaderLabels(columns)
+        self.resultsTable.setRowCount(0)
+        header = self.resultsTable.horizontalHeader()
+        for i in range(len(columns)):
+            if columns[i] == self.tr("Actions"):
+                header.setSectionResizeMode(i, QHeaderView.ResizeToContents)
+            else:
+                header.setSectionResizeMode(i, QHeaderView.Stretch)
+
+    def _on_selection_changed(self):
+        """Enable or disable the Delete Selected button based on selection."""
+        has_selection = bool(self.resultsTable.selectionModel().selectedRows())
+        self.btn_delete_selected.setEnabled(
+            has_selection and self._delete_selected_callback is not None
+        )
+
+    def _get_selected_rows(self):
+        """Return the row data for all currently selected table rows."""
+        selected = []
+        start = self._current_page * self._page_size
+        for index in self.resultsTable.selectionModel().selectedRows():
+            row_idx = start + index.row()
+            if row_idx < len(self._filtered_rows):
+                selected.append(self._filtered_rows[row_idx])
+        return selected
+
+    def _populate_rows(self, rows):
+        """Store all rows and show the first page."""
+        self._all_rows = rows
+        self._current_page = 0
+        self._apply_filter()
+
+    def _apply_filter(self):
+        """Filter _all_rows by the current search text, then show page."""
+        search = self.searchBox.text().lower()
+        if search:
+            self._filtered_rows = [
+                row
+                for row in self._all_rows
+                if any(search in str(v).lower() for v in row)
+            ]
+        else:
+            self._filtered_rows = list(self._all_rows)
+        self._current_page = 0
+        self._show_page()
+
+    @property
+    def _total_pages(self):
+        """Total number of pages for the current filtered rows."""
+        return max(
+            1, (len(self._filtered_rows) + self._page_size - 1) // self._page_size
+        )
+
+    def _show_page(self):
+        """Render the current page of _filtered_rows into the table."""
+        total = len(self._filtered_rows)
+        start = self._current_page * self._page_size
+        end = min(start + self._page_size, total)
+        page_rows = self._filtered_rows[start:end]
+
+        data_col_count = self.resultsTable.columnCount()
+        if self._row_actions:
+            data_col_count -= 1  # last column is for action buttons
+
+        self.resultsTable.setRowCount(len(page_rows))
+        for row_idx, values in enumerate(page_rows):
+            for col, val in enumerate(values):
+                click_cb = None
+                if col == 0 and self._name_click_callback:
+                    click_cb = self._name_click_callback
+                elif col in self._extra_click_callbacks:
+                    click_cb = self._extra_click_callbacks[col]
+                if click_cb:
+                    # Clickable cell
+                    link = QPushButton(str(val))
+                    link.setFlat(True)
+                    link.setCursor(Qt.PointingHandCursor)
+                    link.setStyleSheet(
+                        "text-align: left; color: palette(link); "
+                        "text-decoration: underline; padding: 0 4px;"
+                    )
+                    link.clicked.connect(partial(click_cb, values))
+                    self.resultsTable.setCellWidget(row_idx, col, link)
+                else:
+                    self.resultsTable.setItem(
+                        row_idx,
+                        col,
+                        QTableWidgetItem("—" if val is None else str(val)),
+                    )
+            if self._row_actions:
+                self.resultsTable.setCellWidget(
+                    row_idx, data_col_count, self._make_action_widget(values)
+                )
+
+        # Update pagination controls
+        self.lbl_page_number.setText(str(self._current_page + 1))
+
+        if total == 0:
+            self.lbl_page_info.setText(self.tr("No results"))
+        else:
+            self.lbl_page_info.setText(
+                self.tr("Results {} to {} (out of {} items)").format(
+                    start + 1, end, total
+                )
+            )
+
+        self.btn_page_first.setEnabled(self._current_page > 0)
+        self.btn_page_prev.setEnabled(self._current_page > 0)
+        self.btn_page_next.setEnabled(self._current_page + 1 < self._total_pages)
+        self.btn_page_last.setEnabled(self._current_page + 1 < self._total_pages)
+
+    def _make_action_widget(self, row_data):
+        """Create a widget with icon action buttons for a table row."""
+        widget = QWidget()
+        layout = QHBoxLayout(widget)
+        layout.setContentsMargins(2, 0, 2, 0)
+        layout.setSpacing(4)
+        for icon_name, tooltip, callback in self._row_actions:
+            btn = QPushButton()
+            btn.setIcon(QIcon(QgsApplication.iconPath(icon_name)))
+            btn.setToolTip(tooltip)
+            btn.setFlat(True)
+            btn.setFixedSize(24, 24)
+            btn.clicked.connect(partial(callback, row_data))
+            layout.addWidget(btn)
+        return widget
+
+    # -- Pagination slots --------------------------------------------------
+
+    def _page_first(self):
+        self._current_page = 0
+        self._show_page()
+
+    def _page_prev(self):
+        if self._current_page > 0:
+            self._current_page -= 1
+            self._show_page()
+
+    def _page_next(self):
+        if self._current_page + 1 < self._total_pages:
+            self._current_page += 1
+            self._show_page()
+
+    def _page_last(self):
+        self._current_page = self._total_pages - 1
+        self._show_page()
+
+    def _fetch_list(self, api_method, *args):
+        """Call a geoservercloud list endpoint. Returns a list or []."""
+        try:
+            result, _ = api_method(*args)
+            return result if isinstance(result, list) else []
+        except Exception as e:
+            self.log(
+                f"API error ({api_method.__name__}): {e}",
+                log_level=Qgis.MessageLevel.Warning,
+            )
+            return []
+
+    def _filter_table(self, _text):
+        """Filter rows by search text and reset to first page."""
+        self._apply_filter()
+
+    def _confirm_delete(self, resource_type, name):
+        """Show a confirmation dialog before deleting a resource.
+
+        :param resource_type: human-readable type (e.g. "workspace").
+        :param name: name of the resource to delete.
+        :return: True if the user confirmed deletion.
+        """
+        reply = QMessageBox.warning(
+            self,
+            self.tr("Confirm Delete"),
+            self.tr(
+                "Are you sure you want to delete {type} '{name}'?\n\n"
+                "This action cannot be undone."
+            ).format(type=resource_type, name=name),
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        return reply == QMessageBox.Yes
+
+    # -- Dialog actions ----------------------------------------------------
+
+    def _edit_credentials(self):
+        """Open the plugin's settings page."""
+        if self.iface:
+            self.hide()
+            self.iface.showOptionsDialog(currentPage=f"mOptionsPage{__title__}")
+            self.refresh_ui(show_message=True)
+            self.show()

--- a/geoserver_manager/gui/dlg_main.ui
+++ b/geoserver_manager/gui/dlg_main.ui
@@ -1,161 +1,379 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>GeoServerMainDialogBase</class>
- <widget class="QDialog" name="GeoServerMainDialogBase">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>200</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>GeoServer Manager</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QLabel" name="lbl_header">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>GeoServer Cloud Connection</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="grp_status">
-     <property name="title">
-      <string>Status</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="lbl_url_label">
-        <property name="text">
-         <string>Server URL:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="lbl_url_value">
-        <property name="text">
-         <string>Not configured</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="lbl_status_label">
-        <property name="text">
-         <string>Connection Status:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="lbl_status_value">
-        <property name="text">
-         <string>Unknown</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
+  <class>GeoServerMainDialogBase</class>
+  <widget class="QDialog" name="GeoServerMainDialogBase">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>900</width>
+        <height>600</height>
+      </rect>
+    </property>
+    <property name="minimumSize">
       <size>
-       <width>20</width>
-       <height>40</height>
+        <width>700</width>
+        <height>450</height>
       </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="btn_edit_credentials">
-       <property name="text">
-        <string>Edit Credentials...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btn_test_connection">
-       <property name="text">
-        <string>Test Connection</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Close</set>
-       </property>
-      </widget>
-     </item>
+    </property>
+    <property name="windowTitle">
+      <string>GeoServer Manager</string>
+    </property>
+    <layout class="QVBoxLayout" name="mainLayout">
+      <property name="leftMargin">
+        <number>4</number>
+      </property>
+      <property name="topMargin">
+        <number>4</number>
+      </property>
+      <property name="rightMargin">
+        <number>4</number>
+      </property>
+      <property name="bottomMargin">
+        <number>4</number>
+      </property>
+      <property name="spacing">
+        <number>4</number>
+      </property>
+      <!-- Message bar placeholder -->
+      <item>
+        <layout class="QVBoxLayout" name="message_bar_layout">
+          <property name="spacing">
+            <number>0</number>
+          </property>
+        </layout>
+      </item>
+      <!-- Main content: nav tabs + results -->
+      <item>
+        <widget class="QSplitter" name="splitter">
+          <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="childrenCollapsible">
+            <bool>false</bool>
+          </property>
+          <!-- Left navigation panel -->
+          <widget class="QWidget" name="leftPanel">
+            <property name="minimumSize">
+              <size>
+                <width>140</width>
+                <height>0</height>
+              </size>
+            </property>
+            <property name="maximumSize">
+              <size>
+                <width>200</width>
+                <height>16777215</height>
+              </size>
+            </property>
+            <layout class="QVBoxLayout" name="leftLayout">
+              <property name="leftMargin">
+                <number>0</number>
+              </property>
+              <property name="topMargin">
+                <number>0</number>
+              </property>
+              <property name="rightMargin">
+                <number>0</number>
+              </property>
+              <property name="bottomMargin">
+                <number>0</number>
+              </property>
+              <item>
+                <widget class="QListWidget" name="navList">
+                  <property name="styleSheet">
+                    <string notr="true">
+           QListWidget {
+             font-size: 13px;
+           }
+           QListWidget::item {
+             padding: 10px 12px;
+           }
+           QListWidget::item:selected {
+             background-color: palette(highlight);
+             color: palette(highlighted-text);
+           }
+                    </string>
+                  </property>
+                  <property name="iconSize">
+                    <size>
+                      <width>20</width>
+                      <height>20</height>
+                    </size>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </widget>
+          <!-- Right results panel -->
+          <widget class="QWidget" name="rightPanel">
+            <layout class="QVBoxLayout" name="rightLayout">
+              <property name="leftMargin">
+                <number>4</number>
+              </property>
+              <property name="topMargin">
+                <number>0</number>
+              </property>
+              <property name="rightMargin">
+                <number>0</number>
+              </property>
+              <property name="bottomMargin">
+                <number>0</number>
+              </property>
+              <!-- Header: add button + search -->
+              <item>
+                <layout class="QHBoxLayout" name="headerLayout">
+                  <item>
+                    <widget class="QPushButton" name="btn_add">
+                      <property name="text">
+                        <string>Add</string>
+                      </property>
+                      <property name="visible">
+                        <bool>false</bool>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <widget class="QPushButton" name="btn_delete_selected">
+                      <property name="text">
+                        <string>Delete Selected</string>
+                      </property>
+                      <property name="visible">
+                        <bool>false</bool>
+                      </property>
+                      <property name="enabled">
+                        <bool>false</bool>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <spacer name="headerSpacer">
+                      <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                        <size>
+                          <width>40</width>
+                          <height>20</height>
+                        </size>
+                      </property>
+                    </spacer>
+                  </item>
+                  <item>
+                    <widget class="QLineEdit" name="searchBox">
+                      <property name="placeholderText">
+                        <string>Search...</string>
+                      </property>
+                      <property name="clearButtonEnabled">
+                        <bool>true</bool>
+                      </property>
+                      <property name="minimumSize">
+                        <size>
+                          <width>200</width>
+                          <height>0</height>
+                        </size>
+                      </property>
+                      <property name="maximumSize">
+                        <size>
+                          <width>300</width>
+                          <height>16777215</height>
+                        </size>
+                      </property>
+                    </widget>
+                  </item>
+                </layout>
+              </item>
+              <!-- Results table -->
+              <item>
+                <widget class="QTableWidget" name="resultsTable">
+                  <property name="alternatingRowColors">
+                    <bool>true</bool>
+                  </property>
+                  <property name="selectionBehavior">
+                    <enum>QAbstractItemView::SelectRows</enum>
+                  </property>
+                  <property name="selectionMode">
+                    <enum>QAbstractItemView::ExtendedSelection</enum>
+                  </property>
+                  <property name="sortingEnabled">
+                    <bool>true</bool>
+                  </property>
+                  <property name="editTriggers">
+                    <set>QAbstractItemView::NoEditTriggers</set>
+                  </property>
+                  <property name="horizontalScrollMode">
+                    <enum>QAbstractItemView::ScrollPerPixel</enum>
+                  </property>
+                </widget>
+              </item>
+              <!-- Pagination bar -->
+              <item>
+                <layout class="QHBoxLayout" name="paginationLayout">
+                  <item>
+                    <widget class="QPushButton" name="btn_page_first">
+                      <property name="text">
+                        <string>&lt;&lt;</string>
+                      </property>
+                      <property name="maximumSize">
+                        <size>
+                          <width>36</width>
+                          <height>16777215</height>
+                        </size>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <widget class="QPushButton" name="btn_page_prev">
+                      <property name="text">
+                        <string>&lt;</string>
+                      </property>
+                      <property name="maximumSize">
+                        <size>
+                          <width>36</width>
+                          <height>16777215</height>
+                        </size>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <widget class="QLabel" name="lbl_page_number">
+                      <property name="text">
+                        <string>1</string>
+                      </property>
+                      <property name="alignment">
+                        <set>Qt::AlignCenter</set>
+                      </property>
+                      <property name="minimumSize">
+                        <size>
+                          <width>28</width>
+                          <height>0</height>
+                        </size>
+                      </property>
+                      <property name="styleSheet">
+                        <string notr="true">
+             QLabel {
+               background-color: palette(highlight);
+               color: palette(highlighted-text);
+               padding: 2px 6px;
+               border-radius: 3px;
+             }
+                        </string>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <widget class="QPushButton" name="btn_page_next">
+                      <property name="text">
+                        <string>&gt;</string>
+                      </property>
+                      <property name="maximumSize">
+                        <size>
+                          <width>36</width>
+                          <height>16777215</height>
+                        </size>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <widget class="QPushButton" name="btn_page_last">
+                      <property name="text">
+                        <string>&gt;&gt;</string>
+                      </property>
+                      <property name="maximumSize">
+                        <size>
+                          <width>36</width>
+                          <height>16777215</height>
+                        </size>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <widget class="QLabel" name="lbl_page_info">
+                      <property name="text">
+                        <string>Results 0 to 0 (out of 0 items)</string>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
+                    <spacer name="paginationSpacer">
+                      <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                        <size>
+                          <width>40</width>
+                          <height>20</height>
+                        </size>
+                      </property>
+                    </spacer>
+                  </item>
+                </layout>
+              </item>
+            </layout>
+          </widget>
+        </widget>
+      </item>
+      <!-- Bottom bar -->
+      <item>
+        <layout class="QHBoxLayout" name="bottomLayout">
+          <item>
+            <widget class="QPushButton" name="btn_refresh">
+              <property name="text">
+                <string>Refresh</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <widget class="QPushButton" name="btn_edit_credentials">
+              <property name="text">
+                <string>Settings...</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <spacer name="bottomSpacer">
+              <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+                <size>
+                  <width>40</width>
+                  <height>20</height>
+                </size>
+              </property>
+            </spacer>
+          </item>
+          <item>
+            <widget class="QLabel" name="lbl_status">
+              <property name="text">
+                <string>Disconnected</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <spacer name="bottomSpacer2">
+              <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+                <size>
+                  <width>40</width>
+                  <height>20</height>
+                </size>
+              </property>
+            </spacer>
+          </item>
+          <item>
+            <widget class="QPushButton" name="btn_close">
+              <property name="text">
+                <string>Close</string>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </item>
     </layout>
-   </item>
-  </layout>
- </widget>
- <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>GeoServerMainDialogBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>GeoServerMainDialogBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+  </widget>
+  <resources/>
+  <connections/>
 </ui>

--- a/geoserver_manager/gui/dlg_resource_form.py
+++ b/geoserver_manager/gui/dlg_resource_form.py
@@ -16,7 +16,7 @@ Usage:
         fields=fields,
         parent=self,
     )
-    if dlg.exec_() == QDialog.Accepted:
+    if dlg.exec() == QDialog.DialogCode.Accepted:
         values = dlg.get_values()
 
 For edit mode, pass existing values:
@@ -123,9 +123,11 @@ class ResourceFormDialog(QDialog):
 
         # Buttons
         self._button_box = QDialogButtonBox(
-            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
-        self._button_box.button(QDialogButtonBox.Ok).setText(self.tr("Save"))
+        self._button_box.button(QDialogButtonBox.StandardButton.Ok).setText(
+            self.tr("Save")
+        )
         self._button_box.accepted.connect(self._on_accept)
         self._button_box.rejected.connect(self.reject)
         layout.addWidget(self._button_box)
@@ -144,8 +146,8 @@ class ResourceFormDialog(QDialog):
         """Build a QWidget containing a QFormLayout for the given fields."""
         container = QWidget()
         form = QFormLayout(container)
-        form.setLabelAlignment(Qt.AlignLeft)
-        form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
+        form.setLabelAlignment(Qt.AlignmentFlag.AlignLeft)
+        form.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         form.setHorizontalSpacing(12)
         form.setVerticalSpacing(8)
 
@@ -171,7 +173,9 @@ class ResourceFormDialog(QDialog):
                 help_label = QLabel(help_text)
                 help_label.setWordWrap(True)
                 help_label.setStyleSheet("color: gray; font-size: 11px;")
-                help_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+                help_label.setSizePolicy(
+                    QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+                )
                 wrapper.addWidget(help_label)
 
             form.addRow(label, wrapper_widget)
@@ -200,7 +204,7 @@ class ResourceFormDialog(QDialog):
         if ftype == "text":
             w = QLineEdit()
             if field.get("echo_password"):
-                w.setEchoMode(QLineEdit.Password)
+                w.setEchoMode(QLineEdit.EchoMode.Password)
             if value:
                 w.setText(str(value))
             placeholder = field.get("placeholder")

--- a/geoserver_manager/gui/dlg_resource_form.py
+++ b/geoserver_manager/gui/dlg_resource_form.py
@@ -1,0 +1,351 @@
+#! python3  # noqa: E265
+
+"""
+Reusable modal form dialog for creating and editing GeoServer resources.
+
+Usage:
+    fields = [
+        {"key": "name", "label": "Name", "type": "text", "required": True},
+        {"key": "uri", "label": "Namespace URI", "type": "text",
+         "help": "The namespace URI associated with this workspace"},
+        {"key": "isolated", "label": "Isolated Workspace", "type": "checkbox"},
+    ]
+    dlg = ResourceFormDialog(
+        title="New Workspace",
+        description="Configure a new workspace",
+        fields=fields,
+        parent=self,
+    )
+    if dlg.exec_() == QDialog.Accepted:
+        values = dlg.get_values()
+
+For edit mode, pass existing values:
+    dlg = ResourceFormDialog(
+        title="Edit Workspace 'my_ws'",
+        fields=fields,
+        values={"name": "my_ws", "isolated": False},
+        parent=self,
+    )
+
+Supported field types:
+    - "text"      -> QLineEdit
+    - "checkbox"  -> QCheckBox
+    - "combo"     -> QComboBox (provide "options": ["a", "b", ...])
+    - "spinbox"   -> QSpinBox (optional "min", "max", "default")
+    - "textarea"  -> QPlainTextEdit
+
+Field options:
+    - key (str): identifier used in get_values()
+    - label (str): display label
+    - type (str): widget type (see above)
+    - required (bool): mark as mandatory (default False)
+    - default: default value
+    - help (str): hint text shown below the widget
+    - placeholder (str): placeholder text for text/textarea
+    - options (list[str]): choices for "combo"
+    - min/max (int): range for "spinbox"
+    - read_only (bool): disable editing
+    - group (str): optional tab group name — fields with the same group
+      appear under one tab; ungrouped fields go to the first tab
+    - on_change (callable): for "combo" fields, called with (new_value)
+      when the selection changes
+    - visible (bool): initial visibility (default True)
+"""
+
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QPlainTextEdit,
+    QSizePolicy,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class ResourceFormDialog(QDialog):
+    """Generic modal form dialog built from a field definition list."""
+
+    def __init__(self, title, fields, values=None, description=None, parent=None):
+        """
+        :param title: dialog window title.
+        :param fields: list of field dicts (see module docstring).
+        :param values: dict of existing values to pre-fill (edit mode).
+        :param description: optional subtitle shown below the title.
+        :param parent: parent widget.
+        """
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setMinimumWidth(450)
+
+        self._fields = fields
+        self._widgets = {}  # key -> widget
+        self._row_widgets = {}  # key -> (label_widget, wrapper_widget) for visibility
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+
+        # Header
+        title_label = QLabel(title)
+        title_label.setStyleSheet("font-size: 14px; font-weight: bold;")
+        layout.addWidget(title_label)
+
+        if description:
+            desc_label = QLabel(description)
+            desc_label.setWordWrap(True)
+            desc_label.setStyleSheet("color: gray; margin-bottom: 6px;")
+            layout.addWidget(desc_label)
+
+        # Group fields by tab
+        groups = self._collect_groups(fields)
+
+        if len(groups) == 1:
+            # Single group — no tabs needed
+            form = self._build_form(list(groups.values())[0], values)
+            layout.addWidget(form)
+        else:
+            # Multiple groups — use tabs
+            tabs = QTabWidget()
+            for group_name, group_fields in groups.items():
+                page = self._build_form(group_fields, values)
+                tabs.addTab(page, group_name)
+            layout.addWidget(tabs)
+
+        # Stretch to push buttons to the bottom
+        layout.addStretch()
+
+        # Buttons
+        self._button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        self._button_box.button(QDialogButtonBox.Ok).setText(self.tr("Save"))
+        self._button_box.accepted.connect(self._on_accept)
+        self._button_box.rejected.connect(self.reject)
+        layout.addWidget(self._button_box)
+
+    @staticmethod
+    def _collect_groups(fields):
+        """Organise fields into ordered groups (preserves insertion order)."""
+        groups = {}
+        default_group = "General"
+        for field in fields:
+            group = field.get("group", default_group)
+            groups.setdefault(group, []).append(field)
+        return groups
+
+    def _build_form(self, fields, values):
+        """Build a QWidget containing a QFormLayout for the given fields."""
+        container = QWidget()
+        form = QFormLayout(container)
+        form.setLabelAlignment(Qt.AlignLeft)
+        form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
+        form.setHorizontalSpacing(12)
+        form.setVerticalSpacing(8)
+
+        for field in fields:
+            widget = self._create_widget(field, values)
+            self._widgets[field["key"]] = widget
+
+            # Label
+            label_text = field["label"]
+            if field.get("required"):
+                label_text += " *"
+            label = QLabel(label_text)
+
+            # Build a wrapper that stacks the widget + optional help text
+            wrapper_widget = QWidget()
+            wrapper = QVBoxLayout(wrapper_widget)
+            wrapper.setSpacing(2)
+            wrapper.setContentsMargins(0, 0, 0, 0)
+            wrapper.addWidget(widget)
+
+            help_text = field.get("help")
+            if help_text:
+                help_label = QLabel(help_text)
+                help_label.setWordWrap(True)
+                help_label.setStyleSheet("color: gray; font-size: 11px;")
+                help_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+                wrapper.addWidget(help_label)
+
+            form.addRow(label, wrapper_widget)
+            self._row_widgets[field["key"]] = (label, wrapper_widget)
+
+            # Initial visibility
+            if field.get("visible") is False:
+                label.setVisible(False)
+                wrapper_widget.setVisible(False)
+
+            # on_change callback for combo widgets
+            if field.get("type") == "combo" and field.get("on_change"):
+                cb = field["on_change"]
+                widget.currentTextChanged.connect(cb)
+
+        return container
+
+    def _create_widget(self, field, values):
+        """Instantiate the appropriate widget for a field definition."""
+        ftype = field.get("type", "text")
+        key = field["key"]
+        default = field.get("default", "" if ftype == "text" else None)
+        value = values.get(key, default) if values else default
+        read_only = field.get("read_only", False)
+
+        if ftype == "text":
+            w = QLineEdit()
+            if field.get("echo_password"):
+                w.setEchoMode(QLineEdit.Password)
+            if value:
+                w.setText(str(value))
+            placeholder = field.get("placeholder")
+            if placeholder:
+                w.setPlaceholderText(placeholder)
+            if read_only:
+                w.setEnabled(False)
+            return w
+
+        if ftype == "checkbox":
+            w = QCheckBox()
+            w.setChecked(bool(value))
+            if read_only:
+                w.setEnabled(False)
+            return w
+
+        if ftype == "combo":
+            w = QComboBox()
+            options = field.get("options", [])
+            w.addItems(options)
+            if value and value in options:
+                w.setCurrentText(str(value))
+            if read_only:
+                w.setEnabled(False)
+            return w
+
+        if ftype == "spinbox":
+            w = QSpinBox()
+            w.setMinimum(field.get("min", 0))
+            w.setMaximum(field.get("max", 99999))
+            if value is not None:
+                w.setValue(int(value))
+            if read_only:
+                w.setReadOnly(True)
+            return w
+
+        if ftype == "textarea":
+            w = QPlainTextEdit()
+            w.setMaximumHeight(120)
+            if value:
+                w.setPlainText(str(value))
+            placeholder = field.get("placeholder")
+            if placeholder:
+                w.setPlaceholderText(placeholder)
+            if read_only:
+                w.setReadOnly(True)
+            return w
+
+        # Fallback to text
+        w = QLineEdit()
+        if value:
+            w.setText(str(value))
+        return w
+
+    def get_values(self):
+        """Return a dict of field key -> current value."""
+        result = {}
+        for field in self._fields:
+            key = field["key"]
+            widget = self._widgets[key]
+            ftype = field.get("type", "text")
+
+            if ftype == "text":
+                result[key] = widget.text().strip()
+            elif ftype == "checkbox":
+                result[key] = widget.isChecked()
+            elif ftype == "combo":
+                result[key] = widget.currentText()
+            elif ftype == "spinbox":
+                result[key] = widget.value()
+            elif ftype == "textarea":
+                result[key] = widget.toPlainText().strip()
+            else:
+                result[key] = widget.text().strip()
+        return result
+
+    def set_field_visible(self, key, visible):
+        """Show or hide a field by key.
+
+        :param key: field key identifier.
+        :param visible: True to show, False to hide.
+        """
+        if key in self._row_widgets:
+            label, wrapper = self._row_widgets[key]
+            label.setVisible(visible)
+            wrapper.setVisible(visible)
+
+    def get_widget(self, key):
+        """Return the widget for a field by key.
+
+        :param key: field key identifier.
+        :return: the widget, or None if key not found.
+        """
+        return self._widgets.get(key)
+
+    def set_all_fields_enabled(self, enabled):
+        """Enable or disable all field widgets.
+
+        :param enabled: True to enable, False to disable.
+        """
+        for widget in self._widgets.values():
+            widget.setEnabled(enabled)
+
+    def _on_accept(self):
+        """Validate required fields before accepting."""
+        # Reset styles
+        for field in self._fields:
+            widget = self._widgets[field["key"]]
+            if not field.get("read_only"):
+                widget.setStyleSheet("")
+
+        for field in self._fields:
+            if not field.get("required"):
+                continue
+            # Skip hidden fields
+            key = field["key"]
+            if key in self._row_widgets:
+                _, wrapper = self._row_widgets[key]
+                if not wrapper.isVisible():
+                    continue
+            value = self.get_values()[key]
+            if not value:
+                widget = self._widgets[key]
+                widget.setFocus()
+                widget.setStyleSheet("border: 1px solid red;")
+                return
+
+        self.accept()
+
+    def set_field_value(self, key, value):
+        """Programmatically set a field value by key."""
+        if key not in self._widgets:
+            return
+        widget = self._widgets[key]
+        field = next((f for f in self._fields if f["key"] == key), None)
+        if not field:
+            return
+        ftype = field.get("type", "text")
+        if ftype == "text":
+            widget.setText(str(value) if value else "")
+        elif ftype == "checkbox":
+            widget.setChecked(bool(value))
+        elif ftype == "combo":
+            widget.setCurrentText(str(value))
+        elif ftype == "spinbox":
+            widget.setValue(int(value) if value else 0)
+        elif ftype == "textarea":
+            widget.setPlainText(str(value) if value else "")

--- a/geoserver_manager/gui/dlg_settings.py
+++ b/geoserver_manager/gui/dlg_settings.py
@@ -8,8 +8,8 @@ Plugin settings form integrated into QGIS 'Options' menu.
 import platform
 from functools import partial
 from pathlib import Path
-from urllib.parse import quote
 from typing import Callable
+from urllib.parse import quote
 
 # PyQGIS
 from qgis.core import Qgis, QgsApplication
@@ -29,7 +29,6 @@ from geoserver_manager.__about__ import (
 )
 from geoserver_manager.toolbelt import PlgLogger, PlgOptionsManager
 from geoserver_manager.toolbelt.preferences import PlgSettingsStructure
-
 
 # ############################################################################
 # ########## Classes ###############
@@ -63,17 +62,13 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
         self.lbl_title.setText(f"{__title__} - Version {__version__}")
 
         # customization
-        self.btn_help.setIcon(
-            QIcon(QgsApplication.iconPath("mActionHelpContents.svg"))
-        )
+        self.btn_help.setIcon(QIcon(QgsApplication.iconPath("mActionHelpContents.svg")))
         self.btn_help.pressed.connect(
             partial(QDesktopServices.openUrl, QUrl(__uri_homepage__))
         )
 
         self.btn_report.setIcon(
-            QIcon(QgsApplication.iconPath(
-                "console/iconSyntaxErrorConsole.svg"
-            ))
+            QIcon(QgsApplication.iconPath("console/iconSyntaxErrorConsole.svg"))
         )
         self.btn_report.pressed.connect(
             partial(
@@ -86,9 +81,7 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
             )
         )
 
-        self.btn_reset.setIcon(
-            QIcon(QgsApplication.iconPath("mActionUndo.svg"))
-        )
+        self.btn_reset.setIcon(QIcon(QgsApplication.iconPath("mActionUndo.svg")))
         self.btn_reset.pressed.connect(self.on_reset_settings)
 
         # load previously saved settings
@@ -103,7 +96,15 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
         settings.version = __version__
 
         # geoserver URL (not sensitive — stored in QgsSettings)
-        settings.geoserver_url = self.txt_gs_url.text()
+        url = self.txt_gs_url.text().strip()
+        if url and not url.startswith(("http://", "https://")):
+            self.log(
+                message="GeoServer URL must start with http:// or https://",
+                log_level=Qgis.MessageLevel.Warning,
+                push=True,
+            )
+            return
+        settings.geoserver_url = url
 
         # credentials (sensitive — stored encrypted in QgsAuthManager)
         username = self.txt_gs_username.text()

--- a/geoserver_manager/gui/tab_datastores.py
+++ b/geoserver_manager/gui/tab_datastores.py
@@ -1,0 +1,498 @@
+#! python3  # noqa: E265
+
+"""
+Datastore tab — load, create, edit, delete datastores.
+
+Used as a mixin for GeoServerMainDialog.
+"""
+
+from qgis.core import Qgis
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QDialog, QMessageBox
+
+from geoserver_manager.gui.dlg_resource_form import ResourceFormDialog
+
+# Datastore types supported by the library with dedicated or generic methods
+_SUPPORTED_TYPES = [
+    "PostGIS",
+    "PostGIS (JNDI)",
+    "PMTiles",
+]
+
+# Fields that are specific to each type.
+# Keys match field "key" values used in the form.
+_POSTGIS_KEYS = ["pg_host", "pg_port", "pg_db", "pg_user", "pg_password", "pg_schema"]
+_JNDI_KEYS = ["jndi_reference", "pg_schema"]
+_PMTILES_KEYS = ["pmtiles_url"]
+
+
+class DatastoreTabMixin:
+    """Mixin that adds datastore CRUD methods to the main dialog."""
+
+    def _load_datastores(self):
+        """Fetch all datastores across all workspaces and display them."""
+        self.setCursor(Qt.WaitCursor)
+        try:
+            self._setup_add_button(
+                self.tr("Add a New Datastore"),
+                self.tr("Create a new datastore"),
+                self._add_datastore,
+            )
+            self._setup_delete_selected_button(self._delete_selected_datastores)
+            self._name_click_callback = self._show_datastore_info
+            self._extra_click_callbacks = {1: self._open_workspace_from_row}
+            self._row_actions = [
+                (
+                    "mActionDeleteSelected.svg",
+                    self.tr("Delete"),
+                    self._delete_datastore,
+                ),
+            ]
+            self._setup_table(
+                [
+                    self.tr("Datastore Name"),
+                    self.tr("Workspace"),
+                    self.tr("Type"),
+                    self.tr("Enabled"),
+                    self.tr("Actions"),
+                ]
+            )
+
+            workspaces = self._fetch_list(self.gs.get_workspaces)
+            rows = []
+            for ws in workspaces:
+                ws_name = ws.get("name", str(ws)) if isinstance(ws, dict) else str(ws)
+                datastores = self._fetch_list(self.gs.get_datastores, ws_name)
+                for ds in datastores:
+                    ds_name = (
+                        ds.get("name", str(ds)) if isinstance(ds, dict) else str(ds)
+                    )
+                    try:
+                        detail, _ = self.gs.get_datastore(ws_name, ds_name)
+                        if isinstance(detail, dict):
+                            ds_type = detail.get("type", "—")
+                            enabled = str(detail.get("enabled", True))
+                        else:
+                            ds_type = "—"
+                            enabled = "—"
+                    except Exception:
+                        ds_type = "—"
+                        enabled = "—"
+                    rows.append([ds_name, ws_name, ds_type, enabled])
+
+            self._populate_rows(rows)
+        except Exception as e:
+            self.show_error_message(self.tr("Failed to load datastores: {}").format(e))
+            self.log(f"Datastore load error: {e}", log_level=Qgis.MessageLevel.Critical)
+        finally:
+            self.unsetCursor()
+
+    def _datastore_fields(
+        self, workspace_names, on_type_changed=None, read_only_workspace=False
+    ):
+        """Return datastore form field definitions with type-specific params.
+
+        :param workspace_names: list of workspace names for the combo box.
+        :param on_type_changed: callback(new_type) when the type combo changes.
+        :param read_only_workspace: disable workspace field in edit mode.
+        """
+        return [
+            {
+                "key": "workspace",
+                "label": self.tr("Workspace"),
+                "type": "combo",
+                "options": workspace_names,
+                "required": True,
+                "read_only": read_only_workspace,
+                "help": self.tr("The workspace this datastore belongs to"),
+            },
+            {
+                "key": "name",
+                "label": self.tr("Name"),
+                "type": "text",
+                "required": True,
+            },
+            {
+                "key": "type",
+                "label": self.tr("Type"),
+                "type": "combo",
+                "options": _SUPPORTED_TYPES,
+                "required": True,
+                "on_change": on_type_changed,
+            },
+            {
+                "key": "description",
+                "label": self.tr("Description"),
+                "type": "text",
+                "placeholder": self.tr("Optional description"),
+            },
+            # --- PostGIS fields ---
+            {
+                "key": "pg_host",
+                "label": self.tr("Host"),
+                "type": "text",
+                "required": True,
+                "placeholder": "localhost",
+                "group": self.tr("Connection"),
+            },
+            {
+                "key": "pg_port",
+                "label": self.tr("Port"),
+                "type": "spinbox",
+                "default": 5432,
+                "min": 1,
+                "max": 65535,
+                "group": self.tr("Connection"),
+            },
+            {
+                "key": "pg_db",
+                "label": self.tr("Database"),
+                "type": "text",
+                "required": True,
+                "group": self.tr("Connection"),
+            },
+            {
+                "key": "pg_user",
+                "label": self.tr("User"),
+                "type": "text",
+                "required": True,
+                "group": self.tr("Connection"),
+            },
+            {
+                "key": "pg_password",
+                "label": self.tr("Password"),
+                "type": "text",
+                "required": True,
+                "echo_password": True,
+                "group": self.tr("Connection"),
+            },
+            {
+                "key": "pg_schema",
+                "label": self.tr("Schema"),
+                "type": "text",
+                "default": "public",
+                "group": self.tr("Connection"),
+            },
+            # --- JNDI fields ---
+            {
+                "key": "jndi_reference",
+                "label": self.tr("JNDI Reference"),
+                "type": "text",
+                "required": True,
+                "placeholder": "java:comp/env/jdbc/mydb",
+                "visible": False,
+                "group": self.tr("Connection"),
+                "help": self.tr("JNDI name of the database connection pool"),
+            },
+            # --- PMTiles fields ---
+            {
+                "key": "pmtiles_url",
+                "label": self.tr("PMTiles URL"),
+                "type": "text",
+                "required": True,
+                "placeholder": "file:///mnt/data/tiles.pmtiles",
+                "visible": False,
+                "group": self.tr("Connection"),
+                "help": self.tr(
+                    "Path or URL to the PMTiles file (file://, s3://, gs://, http(s)://)"
+                ),
+            },
+        ]
+
+    def _on_type_changed(self, dlg, new_type):
+        """Show/hide form fields based on the selected datastore type."""
+        for key in _POSTGIS_KEYS:
+            dlg.set_field_visible(key, new_type == "PostGIS")
+        for key in _JNDI_KEYS:
+            dlg.set_field_visible(
+                key,
+                new_type == "PostGIS (JNDI)"
+                or (key == "pg_schema" and new_type == "PostGIS"),
+            )
+        for key in _PMTILES_KEYS:
+            dlg.set_field_visible(key, new_type == "PMTiles")
+
+    def _get_workspace_names(self):
+        """Return a list of workspace names from the current connection."""
+        workspaces = self._fetch_list(self.gs.get_workspaces)
+        return [
+            ws.get("name", str(ws)) if isinstance(ws, dict) else str(ws)
+            for ws in workspaces
+        ]
+
+    def _add_datastore(self):
+        """Open a form dialog to create a new datastore."""
+        workspace_names = self._get_workspace_names()
+        if not workspace_names:
+            self.show_warning_message(
+                self.tr("No workspaces available. Create a workspace first.")
+            )
+            return
+
+        # Build dialog with a deferred on_change so we get a reference to dlg
+        dlg = ResourceFormDialog(
+            title=self.tr("New Datastore"),
+            description=self.tr("Configure a new datastore"),
+            fields=self._datastore_fields(workspace_names),
+            parent=self,
+        )
+        # Wire type combo after dialog is constructed
+        type_combo = dlg.get_widget("type")
+        if type_combo:
+            type_combo.currentTextChanged.connect(
+                lambda t: self._on_type_changed(dlg, t)
+            )
+            # Apply initial visibility for the default type
+            self._on_type_changed(dlg, type_combo.currentText())
+
+        if dlg.exec_() != QDialog.Accepted:
+            return
+
+        values = dlg.get_values()
+        self.setCursor(Qt.WaitCursor)
+        try:
+            self._create_datastore_from_values(values)
+            self.show_success_message(
+                self.tr("Datastore '{}' created.").format(values["name"])
+            )
+            self._load_datastores()
+        except Exception as e:
+            self.show_error_message(
+                self.tr("Failed to create datastore '{}': {}").format(values["name"], e)
+            )
+            self.log(
+                f"Create datastore error: {e}", log_level=Qgis.MessageLevel.Critical
+            )
+        finally:
+            self.unsetCursor()
+
+    def _create_datastore_from_values(self, values):
+        """Call the appropriate library method based on the datastore type."""
+        ws = values["workspace"]
+        name = values["name"]
+        ds_type = values["type"]
+        description = values.get("description") or None
+
+        if ds_type == "PostGIS":
+            self.gs.create_pg_datastore(
+                workspace_name=ws,
+                datastore_name=name,
+                pg_host=values.get("pg_host", ""),
+                pg_port=int(values.get("pg_port", 5432)),
+                pg_db=values.get("pg_db", ""),
+                pg_user=values.get("pg_user", ""),
+                pg_password=values.get("pg_password", ""),
+                pg_schema=values.get("pg_schema", "public") or "public",
+                description=description,
+            )
+        elif ds_type == "PostGIS (JNDI)":
+            self.gs.create_jndi_datastore(
+                workspace_name=ws,
+                datastore_name=name,
+                jndi_reference=values.get("jndi_reference", ""),
+                pg_schema=values.get("pg_schema", "public") or "public",
+                description=description,
+            )
+        elif ds_type == "PMTiles":
+            self.gs.create_pmtiles_datastore(
+                workspace_name=ws,
+                datastore_name=name,
+                pmtiles_url=values.get("pmtiles_url", ""),
+                description=description,
+            )
+        else:
+            raise ValueError(f"Unsupported datastore type: {ds_type}")
+
+    def _show_datastore_info(self, row_data):
+        """Open a form dialog to view/edit an existing datastore."""
+        ds_name = row_data[0]
+        ws_name = row_data[1]
+        ds_type = row_data[2]
+
+        # Fetch full detail for connection_params
+        self.setCursor(Qt.WaitCursor)
+        try:
+            detail, _ = self.gs.get_datastore(ws_name, ds_name)
+        except Exception as e:
+            self.show_error_message(
+                self.tr("Failed to load datastore details: {}").format(e)
+            )
+            return
+        finally:
+            self.unsetCursor()
+
+        conn_params = {}
+        if isinstance(detail, dict):
+            conn_entry = detail.get("connectionParameters", {}).get("entry", {})
+            conn_params = conn_entry if isinstance(conn_entry, dict) else {}
+
+        # Map library type to our supported combo values; unsupported types are read-only
+        type_for_form = ds_type
+        if ds_type not in _SUPPORTED_TYPES:
+            type_for_form = _SUPPORTED_TYPES[0]  # fallback display
+            is_unsupported = True
+        else:
+            is_unsupported = False
+
+        current_values = {
+            "workspace": ws_name,
+            "name": ds_name,
+            "type": type_for_form,
+            "description": (
+                detail.get("description", "") if isinstance(detail, dict) else ""
+            ),
+            # PostGIS fields
+            "pg_host": conn_params.get("host", ""),
+            "pg_port": int(conn_params.get("port", 5432) or 5432),
+            "pg_db": conn_params.get("database", ""),
+            "pg_user": conn_params.get("user", ""),
+            "pg_password": conn_params.get("passwd", ""),
+            "pg_schema": conn_params.get("schema", "public"),
+            # JNDI fields
+            "jndi_reference": conn_params.get("jndiReferenceName", ""),
+            # PMTiles fields
+            "pmtiles_url": conn_params.get("pmtiles", ""),
+        }
+
+        workspace_names = self._get_workspace_names()
+        dlg = ResourceFormDialog(
+            title=self.tr("Edit Datastore '{}'").format(ds_name),
+            description=(
+                self.tr("Modify datastore settings")
+                if not is_unsupported
+                else self.tr(
+                    "Datastore type '{}' is read-only (not supported for editing)"
+                ).format(ds_type)
+            ),
+            fields=self._datastore_fields(workspace_names, read_only_workspace=True),
+            values=current_values,
+            parent=self,
+        )
+
+        if is_unsupported:
+            # Disable all fields — user cannot edit unsupported types
+            dlg.set_all_fields_enabled(False)
+        else:
+            # Wire type combo and apply visibility
+            type_combo = dlg.get_widget("type")
+            if type_combo:
+                type_combo.currentTextChanged.connect(
+                    lambda t: self._on_type_changed(dlg, t)
+                )
+                self._on_type_changed(dlg, type_for_form)
+            # Disable type change in edit mode
+            type_combo.setEnabled(False)
+
+        if dlg.exec_() != QDialog.Accepted:
+            return
+
+        if is_unsupported:
+            return
+
+        values = dlg.get_values()
+        self.setCursor(Qt.WaitCursor)
+        try:
+            self._create_datastore_from_values(values)
+            self.show_success_message(
+                self.tr("Datastore '{}' updated.").format(values["name"])
+            )
+            self._load_datastores()
+        except Exception as e:
+            self.show_error_message(
+                self.tr("Failed to update datastore '{}': {}").format(values["name"], e)
+            )
+            self.log(
+                f"Update datastore error: {e}", log_level=Qgis.MessageLevel.Critical
+            )
+        finally:
+            self.unsetCursor()
+
+    def _delete_datastore(self, row_data):
+        """Delete a single datastore after confirmation."""
+        ds_name, ws_name = row_data[0], row_data[1]
+        if not self._confirm_delete(self.tr("datastore"), f"{ws_name}/{ds_name}"):
+            return
+
+        self.setCursor(Qt.WaitCursor)
+        try:
+            self._do_delete_datastore(ws_name, ds_name)
+            self.show_success_message(
+                self.tr("Datastore '{}' deleted.").format(ds_name)
+            )
+            self._load_datastores()
+        except Exception as e:
+            self.show_error_message(
+                self.tr("Failed to delete datastore '{}': {}").format(ds_name, e)
+            )
+            self.log(
+                f"Delete datastore error: {e}", log_level=Qgis.MessageLevel.Critical
+            )
+        finally:
+            self.unsetCursor()
+
+    def _delete_selected_datastores(self, selected_rows):
+        """Delete multiple datastores after confirmation."""
+        if not selected_rows:
+            return
+
+        labels = [f"{row[1]}/{row[0]}" for row in selected_rows]
+        reply = QMessageBox.warning(
+            self,
+            self.tr("Confirm Delete"),
+            self.tr(
+                "Are you sure you want to delete {} datastore(s)?\n\n{}\n\n"
+                "This action cannot be undone."
+            ).format(len(labels), "\n".join(f"  \u2022 {lbl}" for lbl in labels)),
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            return
+
+        self.setCursor(Qt.WaitCursor)
+        errors = []
+        try:
+            for row in selected_rows:
+                ds_name, ws_name = row[0], row[1]
+                try:
+                    self._do_delete_datastore(ws_name, ds_name)
+                except Exception as e:
+                    errors.append(f"{ws_name}/{ds_name}: {e}")
+            if errors:
+                self.show_error_message(
+                    self.tr("Failed to delete some datastores:\n{}").format(
+                        "\n".join(errors)
+                    )
+                )
+            else:
+                self.show_success_message(
+                    self.tr("{} datastore(s) deleted.").format(len(selected_rows))
+                )
+            self._load_datastores()
+        finally:
+            self.unsetCursor()
+
+    def _do_delete_datastore(self, workspace_name, datastore_name):
+        """Execute the REST DELETE for a datastore (recurse=true removes feature types too)."""
+        # TODO: Replace with gs.delete_datastore() once the library adds this method.
+        # Workaround: direct DELETE to /workspaces/{ws}/datastores/{ds}.json?recurse=true
+        path = self.gs.rest_service.rest_endpoints.datastore(
+            workspace_name, datastore_name
+        )
+        response = self.gs.rest_service.rest_client.delete(
+            path, params={"recurse": "true"}
+        )
+        if response.status_code >= 400:
+            raise Exception(response.content.decode())
+
+    def _open_workspace_from_row(self, row_data):
+        """Open the workspace info dialog for the workspace in a datastore row."""
+        ws_name = row_data[1]
+        try:
+            detail, _ = self.gs.get_workspace(ws_name)
+            isolated = (
+                str(detail.get("isolated", False)) if isinstance(detail, dict) else "—"
+            )
+        except Exception:
+            isolated = "—"
+        self._show_workspace_info([ws_name, isolated])

--- a/geoserver_manager/gui/tab_datastores.py
+++ b/geoserver_manager/gui/tab_datastores.py
@@ -31,7 +31,7 @@ class DatastoreTabMixin:
 
     def _load_datastores(self):
         """Fetch all datastores across all workspaces and display them."""
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             self._setup_add_button(
                 self.tr("Add a New Datastore"),
@@ -245,11 +245,11 @@ class DatastoreTabMixin:
             # Apply initial visibility for the default type
             self._on_type_changed(dlg, type_combo.currentText())
 
-        if dlg.exec_() != QDialog.Accepted:
+        if dlg.exec() != QDialog.DialogCode.Accepted:
             return
 
         values = dlg.get_values()
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             self._create_datastore_from_values(values)
             self.show_success_message(
@@ -310,7 +310,7 @@ class DatastoreTabMixin:
         ds_type = row_data[2]
 
         # Fetch full detail for connection_params
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             detail, _ = self.gs.get_datastore(ws_name, ds_name)
         except Exception as e:
@@ -383,14 +383,14 @@ class DatastoreTabMixin:
             # Disable type change in edit mode
             type_combo.setEnabled(False)
 
-        if dlg.exec_() != QDialog.Accepted:
+        if dlg.exec() != QDialog.DialogCode.Accepted:
             return
 
         if is_unsupported:
             return
 
         values = dlg.get_values()
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             self._create_datastore_from_values(values)
             self.show_success_message(
@@ -413,7 +413,7 @@ class DatastoreTabMixin:
         if not self._confirm_delete(self.tr("datastore"), f"{ws_name}/{ds_name}"):
             return
 
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             self._do_delete_datastore(ws_name, ds_name)
             self.show_success_message(
@@ -443,13 +443,13 @@ class DatastoreTabMixin:
                 "Are you sure you want to delete {} datastore(s)?\n\n{}\n\n"
                 "This action cannot be undone."
             ).format(len(labels), "\n".join(f"  \u2022 {lbl}" for lbl in labels)),
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         errors = []
         try:
             for row in selected_rows:

--- a/geoserver_manager/gui/tab_workspaces.py
+++ b/geoserver_manager/gui/tab_workspaces.py
@@ -18,7 +18,7 @@ class WorkspaceTabMixin:
 
     def _load_workspaces(self):
         """Fetch all workspaces and display them in the results table."""
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             self._setup_add_button(
                 self.tr("Add a New Workspace"),
@@ -92,11 +92,11 @@ class WorkspaceTabMixin:
             fields=self._workspace_fields(),
             parent=self,
         )
-        if dlg.exec_() != QDialog.Accepted:
+        if dlg.exec() != QDialog.DialogCode.Accepted:
             return
 
         values = dlg.get_values()
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             self.gs.create_workspace(
                 values["name"],
@@ -133,12 +133,12 @@ class WorkspaceTabMixin:
             values=current_values,
             parent=self,
         )
-        if dlg.exec_() != QDialog.Accepted:
+        if dlg.exec() != QDialog.DialogCode.Accepted:
             return
 
         values = dlg.get_values()
         new_name = values["name"]
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             if new_name != old_name:
                 # TODO: Replace this workaround with a proper
@@ -190,13 +190,13 @@ class WorkspaceTabMixin:
                 "Are you sure you want to delete {} workspace(s)?\n\n{}\n\n"
                 "This action cannot be undone."
             ).format(len(names), "\n".join(f"  \u2022 {n}" for n in names)),
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         errors = []
         try:
             for name in names:
@@ -224,7 +224,7 @@ class WorkspaceTabMixin:
         if not self._confirm_delete(self.tr("workspace"), name):
             return
 
-        self.setCursor(Qt.WaitCursor)
+        self.setCursor(Qt.CursorShape.WaitCursor)
         try:
             self.gs.delete_workspace(name)
             self.show_success_message(self.tr("Workspace '{}' deleted.").format(name))

--- a/geoserver_manager/gui/tab_workspaces.py
+++ b/geoserver_manager/gui/tab_workspaces.py
@@ -1,0 +1,241 @@
+#! python3  # noqa: E265
+
+"""
+Workspace tab — load, create, edit, delete workspaces.
+
+Used as a mixin for GeoServerMainDialog.
+"""
+
+from qgis.core import Qgis
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QDialog, QMessageBox
+
+from geoserver_manager.gui.dlg_resource_form import ResourceFormDialog
+
+
+class WorkspaceTabMixin:
+    """Mixin that adds workspace CRUD methods to the main dialog."""
+
+    def _load_workspaces(self):
+        """Fetch all workspaces and display them in the results table."""
+        self.setCursor(Qt.WaitCursor)
+        try:
+            self._setup_add_button(
+                self.tr("Add a New Workspace"),
+                self.tr("Create a new workspace"),
+                self._add_workspace,
+            )
+            self._setup_delete_selected_button(self._delete_selected_workspaces)
+            self._name_click_callback = self._show_workspace_info
+            self._extra_click_callbacks = {}
+            self._row_actions = [
+                (
+                    "mActionDeleteSelected.svg",
+                    self.tr("Delete"),
+                    self._delete_workspace,
+                ),
+            ]
+            self._setup_table(
+                [
+                    self.tr("Workspace Name"),
+                    self.tr("Isolated"),
+                    self.tr("Actions"),
+                ]
+            )
+            workspaces = self._fetch_list(self.gs.get_workspaces)
+
+            rows = []
+            for ws in workspaces:
+                name = ws.get("name", str(ws)) if isinstance(ws, dict) else str(ws)
+                detail, _ = self.gs.get_workspace(name)
+                isolated = (
+                    str(detail.get("isolated", False))
+                    if isinstance(detail, dict)
+                    else "—"
+                )
+                rows.append([name, isolated])
+
+            self._populate_rows(rows)
+        except Exception as e:
+            self.show_error_message(self.tr("Failed to load workspaces: {}").format(e))
+            self.log(f"Workspace load error: {e}", log_level=Qgis.MessageLevel.Critical)
+        finally:
+            self.unsetCursor()
+
+    def _workspace_fields(self):
+        """Return workspace form field definitions."""
+        return [
+            {"key": "name", "label": self.tr("Name"), "type": "text", "required": True},
+            {
+                "key": "isolated",
+                "label": self.tr("Isolated Workspace"),
+                "type": "checkbox",
+                "default": False,
+                "help": self.tr(
+                    "Allow objects with the same name to coexist in this workspace"
+                ),
+            },
+            {
+                "key": "set_default",
+                "label": self.tr("Default Workspace"),
+                "type": "checkbox",
+                "default": False,
+                "help": self.tr("Set this as the default workspace for GeoServer"),
+            },
+        ]
+
+    def _add_workspace(self):
+        """Open a form dialog to create a new workspace."""
+        dlg = ResourceFormDialog(
+            title=self.tr("New Workspace"),
+            description=self.tr("Configure a new workspace"),
+            fields=self._workspace_fields(),
+            parent=self,
+        )
+        if dlg.exec_() != QDialog.Accepted:
+            return
+
+        values = dlg.get_values()
+        self.setCursor(Qt.WaitCursor)
+        try:
+            self.gs.create_workspace(
+                values["name"],
+                isolated=values["isolated"],
+                set_default_workspace=values["set_default"],
+            )
+            self.show_success_message(
+                self.tr("Workspace '{}' created.").format(values["name"])
+            )
+            self._load_workspaces()
+        except Exception as e:
+            self.show_error_message(
+                self.tr("Failed to create workspace '{}': {}").format(values["name"], e)
+            )
+            self.log(
+                f"Create workspace error: {e}",
+                log_level=Qgis.MessageLevel.Critical,
+            )
+        finally:
+            self.unsetCursor()
+
+    def _show_workspace_info(self, row_data):
+        """Open a form dialog to view/edit an existing workspace."""
+        old_name = row_data[0]
+        current_values = {
+            "name": old_name,
+            "isolated": row_data[1] == "True",
+            "set_default": False,
+        }
+        dlg = ResourceFormDialog(
+            title=self.tr("Edit Workspace '{}'").format(old_name),
+            description=self.tr("Modify workspace settings"),
+            fields=self._workspace_fields(),
+            values=current_values,
+            parent=self,
+        )
+        if dlg.exec_() != QDialog.Accepted:
+            return
+
+        values = dlg.get_values()
+        new_name = values["name"]
+        self.setCursor(Qt.WaitCursor)
+        try:
+            if new_name != old_name:
+                # TODO: Replace this workaround with a proper
+                # `gs.update_workspace()` method once geoservercloud adds
+                # rename support. See: https://github.com/camptocamp/python-geoservercloud
+                # Workaround: direct PUT to /workspaces/{old_name} with new name.
+                from geoservercloud.models.workspace import Workspace
+
+                ws = Workspace(new_name, values["isolated"])
+                path = self.gs.rest_service.rest_endpoints.workspace(old_name)
+                response = self.gs.rest_service.rest_client.put(
+                    path, json=ws.put_payload()
+                )
+                if response.status_code >= 400:
+                    raise Exception(response.content.decode())
+            else:
+                self.gs.create_workspace(
+                    new_name,
+                    isolated=values["isolated"],
+                    set_default_workspace=values["set_default"],
+                )
+            if values["set_default"]:
+                self.gs.default_workspace = new_name
+            self.show_success_message(
+                self.tr("Workspace '{}' updated.").format(new_name)
+            )
+            self._load_workspaces()
+        except Exception as e:
+            self.show_error_message(
+                self.tr("Failed to update workspace '{}': {}").format(values["name"], e)
+            )
+            self.log(
+                f"Update workspace error: {e}",
+                log_level=Qgis.MessageLevel.Critical,
+            )
+        finally:
+            self.unsetCursor()
+
+    def _delete_selected_workspaces(self, selected_rows):
+        """Delete multiple workspaces after confirmation."""
+        if not selected_rows:
+            return
+
+        names = [row[0] for row in selected_rows]
+        reply = QMessageBox.warning(
+            self,
+            self.tr("Confirm Delete"),
+            self.tr(
+                "Are you sure you want to delete {} workspace(s)?\n\n{}\n\n"
+                "This action cannot be undone."
+            ).format(len(names), "\n".join(f"  \u2022 {n}" for n in names)),
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            return
+
+        self.setCursor(Qt.WaitCursor)
+        errors = []
+        try:
+            for name in names:
+                try:
+                    self.gs.delete_workspace(name)
+                except Exception as e:
+                    errors.append(f"{name}: {e}")
+            if errors:
+                self.show_error_message(
+                    self.tr("Failed to delete some workspaces:\n{}").format(
+                        "\n".join(errors)
+                    )
+                )
+            else:
+                self.show_success_message(
+                    self.tr("{} workspace(s) deleted.").format(len(names))
+                )
+            self._load_workspaces()
+        finally:
+            self.unsetCursor()
+
+    def _delete_workspace(self, row_data):
+        """Delete the workspace after confirmation."""
+        name = row_data[0]
+        if not self._confirm_delete(self.tr("workspace"), name):
+            return
+
+        self.setCursor(Qt.WaitCursor)
+        try:
+            self.gs.delete_workspace(name)
+            self.show_success_message(self.tr("Workspace '{}' deleted.").format(name))
+            self._load_workspaces()
+        except Exception as e:
+            self.show_error_message(
+                self.tr("Failed to delete workspace '{}': {}").format(name, e)
+            )
+            self.log(
+                f"Delete workspace error: {e}",
+                log_level=Qgis.MessageLevel.Critical,
+            )
+        finally:
+            self.unsetCursor()

--- a/geoserver_manager/metadata.txt
+++ b/geoserver_manager/metadata.txt
@@ -10,9 +10,9 @@ tags=geoserver,wms,wfs,workspace,datastore
 # credits and contact
 author=Ronit Jadhav
 email=ronit.jadhav@camptocamp.com
-homepage=http://github.com/ronitjadhav/geoserver_manager/pages
-repository=http://github.com/ronitjadhav/geoserver_manager
-tracker=http://github.com/ronitjadhav/geoserver_manager/issues/
+homepage=https://github.com/ronitjadhav/geoserver_manager/pages
+repository=https://github.com/ronitjadhav/geoserver_manager
+tracker=https://github.com/ronitjadhav/geoserver_manager/issues/
 
 # QGIS context
 deprecated=False

--- a/geoserver_manager/plugin_main.py
+++ b/geoserver_manager/plugin_main.py
@@ -20,9 +20,8 @@ from geoserver_manager.__about__ import (
     __title__,
     __uri_homepage__,
 )
-from geoserver_manager.gui.dlg_settings import PlgOptionsFactory
 from geoserver_manager.gui.dlg_main import GeoServerMainDialog
-
+from geoserver_manager.gui.dlg_settings import PlgOptionsFactory
 from geoserver_manager.toolbelt import PlgLogger, PlgOptionsManager
 
 # ############################################################################
@@ -42,7 +41,6 @@ class GeoServerManagerPlugin:
         self.log = PlgLogger().log
         self.plg_settings = PlgOptionsManager()
         self.main_dialog = None
-        
 
         # translation
         # initialize the locale
@@ -55,7 +53,10 @@ class GeoServerManagerPlugin:
             / "i18n"
             / f"{__title__.lower()}_{self.locale}.qm"
         )
-        self.log(message=f"Translation: {self.locale}, {locale_path}", log_level=Qgis.MessageLevel.NoLevel)
+        self.log(
+            message=f"Translation: {self.locale}, {locale_path}",
+            log_level=Qgis.MessageLevel.NoLevel,
+        )
         if locale_path.exists():
             self.translator = QTranslator()
             self.translator.load(str(locale_path.resolve()))
@@ -63,6 +64,7 @@ class GeoServerManagerPlugin:
 
         # Ensure dependencies are available
         from geoserver_manager.toolbelt.dependencies import ensure_dependencies
+
         self.dependencies_available = ensure_dependencies()
 
     def initGui(self) -> None:  # noqa: N802
@@ -159,47 +161,29 @@ class GeoServerManagerPlugin:
         del self.action_help
 
     def run(self):
-        """Main process.
-
-        :raises Exception: if there is no item in the feed
-        """
+        """Open the main plugin dialog."""
         if not self.dependencies_available:
             return
 
         settings = self.plg_settings.get_plg_settings()
-        
+
         if not settings.has_credentials():
             QMessageBox.information(
                 self.iface.mainWindow(),
                 "GeoServer Manager - Credentials Required",
                 "Welcome to GeoServer Manager!\n\n"
-                "Please configure your GeoServer connection URL, username, and password "
-                "before using the plugin."
+                "Please configure your GeoServer connection URL, "
+                "username, and password before using the plugin.",
             )
-            # Open settings page
-            self.iface.showOptionsDialog(currentPage="mOptionsPage{}".format(__title__))
-            
+            self.iface.showOptionsDialog(currentPage=f"mOptionsPage{__title__}")
+
             # Re-check in case they cancelled
             settings = self.plg_settings.get_plg_settings()
             if not settings.has_credentials():
                 return
-        
-        # Init dialog if not already done
+
         if not self.main_dialog:
             self.main_dialog = GeoServerMainDialog(self.iface.mainWindow(), self.iface)
-            
+
         self.main_dialog.refresh_ui()
         self.main_dialog.show()
-        
-        try:
-            self.log(
-                message=self.tr("Main dialog opened."),
-                log_level=Qgis.MessageLevel.Success,
-                push=False,
-            )
-        except Exception as err:
-            self.log(
-                message=self.tr("Houston, we've got a problem: {}".format(err)),
-                log_level=Qgis.MessageLevel.Critical,
-                push=True,
-            )

--- a/geoserver_manager/toolbelt/preferences.py
+++ b/geoserver_manager/toolbelt/preferences.py
@@ -8,7 +8,7 @@ Plugin settings.
 from dataclasses import asdict, dataclass, fields
 
 # PyQGIS
-from qgis.core import Qgis, QgsApplication, QgsAuthMethodConfig, QgsSettings
+from qgis.core import QgsApplication, QgsAuthMethodConfig, QgsSettings
 
 # package
 import geoserver_manager.toolbelt.log_handler as log_hdlr
@@ -115,6 +115,7 @@ class PlgSettingsStructure:
             auth_mgr.removeAuthenticationConfig(self.geoserver_auth_cfg_id)
             self.geoserver_auth_cfg_id = ""
 
+
 class PlgOptionsManager:
     @staticmethod
     def get_plg_settings() -> PlgSettingsStructure:
@@ -156,20 +157,10 @@ class PlgOptionsManager:
 
     @staticmethod
     def get_value_from_key(key: str, default=None, exp_type=None):
-        """Load and return plugin settings as a dictionary. \
-        Useful to get user preferences across plugin logic.
+        """Load and return a single plugin QSettings value by key.
 
         :return: plugin settings value matching key
         """
-        if not hasattr(PlgSettingsStructure, key):
-            log_hdlr.PlgLogger.log(
-                message="Bad settings key. Must be one of: {}".format(
-                    ",".join(PlgSettingsStructure._fields)
-                ),
-                log_level=Qgis.MessageLevel.Warning,
-            )
-            return None
-
         settings = QgsSettings()
         settings.beginGroup(__title__)
 
@@ -198,15 +189,6 @@ class PlgOptionsManager:
         :return: operation status
         :rtype: bool
         """
-        if not hasattr(PlgSettingsStructure, key):
-            log_hdlr.PlgLogger.log(
-                message="Bad settings key. Must be one of: {}".format(
-                    ",".join(PlgSettingsStructure._fields)
-                ),
-                log_level=Qgis.MessageLevel.Critical,
-            )
-            return False
-
         settings = QgsSettings()
         settings.beginGroup(__title__)
 
@@ -227,15 +209,9 @@ class PlgOptionsManager:
 
     @classmethod
     def save_from_object(cls, plugin_settings_obj: PlgSettingsStructure):
-        """Load and return plugin settings as a dictionary. \
-        Useful to get user preferences across plugin logic.
+        """Save plugin settings from a dataclass object to QgsSettings.
 
-        :return: plugin settings value matching key
+        :param plugin_settings_obj: settings object to persist.
         """
-        settings = QgsSettings()
-        settings.beginGroup(__title__)
-
         for k, v in asdict(plugin_settings_obj).items():
             cls.set_value_from_key(k, v)
-
-        settings.endGroup()


### PR DESCRIPTION
## Summary

Adds a full resource management interface for GeoServer, allowing users to browse, create, edit, and delete workspaces and datastores directly from QGIS.

## What's included

### New UI components
- **Main dialog** with left-side tab navigation, search bar with debounced filtering, paginated results table, and inline message bar
- **Workspace tab** — create, edit (including rename), delete, and bulk-delete workspaces with isolated/default toggles
- **Datastore tab** — create, edit, and delete datastores with support for PostGIS, PostGIS (JNDI), and PMTiles types; dynamic form fields based on selected type
- **ResourceFormDialog** — reusable modal form builder supporting text, checkbox, combo, spinbox, and textarea fields with validation, tab grouping, and help text

### Settings & security
- Settings page with GeoServer URL, username, and password fields
- Credentials stored encrypted via `QgsAuthManager` (not in plaintext QgsSettings)
- Password fields masked in both settings and datastore forms
- URL scheme validation (requires `http://` or `https://`)

### Bug fixes
- `ResourceFormDialog._on_accept()` now calls `self.accept()` so the dialog actually closes on save
- Added missing `set_field_visible()`, `get_widget()`, `set_all_fields_enabled()` public API to `ResourceFormDialog`
- Fixed `__keywords__` parsing (was splitting the repository URL instead of the `tags` metadata key)
- Fixed `PlgOptionsManager.save_from_object()` double-nesting the QgsSettings group
- Consolidated duplicate WHL-loading logic from `__init__.py` into `toolbelt/dependencies.py`
- Updated metadata URLs from `http://` to `https://`

## Testing

- Tested workspace and datastore CRUD operations against a running GeoServer instance
- All existing unit tests pass
- Pre-commit hooks all green (ruff, black, isort, flake8)